### PR TITLE
#168369768 user can view all mentors when logged in 

### DIFF
--- a/controllers/mentors.js
+++ b/controllers/mentors.js
@@ -1,29 +1,31 @@
 
-// import mentorsInfo from '../models/mentorsInfo';
-//
-import { signup, getUser, userData, getMentors } from '../models/createUsers';
+import getMentors from '../models/mentorsInfo';
+import authControllers from '../controllers/auth'
+
 class Mentors{
-	static async output (data){
-		const addedUser = await getUser(data.mentor);
-		const formatted = await{
-			id: addedUser.id,
-			firstName: addedUser.firstname,
-			lastName: addedUser.lastname,
-			email: addedUser.email,
-			address: addedUser.address,
-			bio: addedUser.bio,
-			occupation: addedUser.occupation,
-			expertise: addedUser.expertise,
-			mentor: addedUser.mentor
-		}
-		return formatted;
-	}
+	
 	static async allMentors(request,response){
-		response.status(200).json({
-		status: 200,
-		data: await Mentors.output()
-		});
+		try{
+			const mentors = await getMentors();
+			if(mentors){
+				mentors.forEach((mentor)=>{
+					delete mentor.password;
+				});
+				response.status(200).json({
+					status: 200,
+					data: mentors
+				});
+			}else{
+				response.status(404).json({
+					status: 404,
+					message: 'mentors not found'
+				});
+			}			
+		}catch (error) {
+			throw error;
+		  }
 	}
+	
 	static oneMentor(request,response){
 		response.status(200).json({
 		status: 200,

--- a/models/mentorsInfo.js
+++ b/models/mentorsInfo.js
@@ -1,16 +1,15 @@
-const mentorsInfo =[
-{
-	userId: 2,
-	firstName:"cynthia",
-	lastName:"jggf",
-	email:"cynmumbua@yahoo.com",
-	password:"$2b$06$O0appTOYE18OM7EGSYKIR.AgrZCFlD6G4LnXtXngpxG18DvJrNNBO",
-	address:"juja",
-	bio:"loves pets",
-	occupation:"vet",
-	expertise:"animals",
-	mentor: true
-}
-];
 
-module.exports=mentorsInfo;
+import query  from './sessions';
+
+const getMentors = async() =>{
+    const getMentor = `SELECT * FROM users WHERE mentor= 'true'`;
+    try{
+        const { rows } = await query(getMentor);
+        return rows;
+    } catch(error){
+        return error;
+    }
+}
+
+
+module.exports= getMentors;


### PR DESCRIPTION
#### What does this PR do?
Lists all mentors in the DB when a user logs in
Lists new mentors when created
Removes mentor password from the response

#### Description of Task to be completed
List all mentors in the DB when the user logs in
List new mentors
Should remove mentor password from the response

#### How should this be manually tested?
[How the LFA can test it]

#### Any background context you want to provide?

#### What are the relevant pivotal tracker stories?
PT stories #168369768
#### Screenshots (if appropriate)
